### PR TITLE
fix bug

### DIFF
--- a/reactor/s03/test6.cc
+++ b/reactor/s03/test6.cc
@@ -19,7 +19,6 @@ int main()
   sleep(1);
   loop->runAfter(2, runInThread);
   sleep(3);
-  loop->quit();
 
   printf("exit main().\n");
 }


### PR DESCRIPTION
EventLoopThread对象析构时会自动调用EventLoop的quit函数，不需要手动quit，否则会出现两次wakeup， 导致EventLoopThread对象析构时出现“EventLoop::wakeup() writes -1 bytes instead of 8”的错误。