### PR TITLE
fix ttcp make error

### DIFF
--- a/tpc/Makefile
+++ b/tpc/Makefile
@@ -20,7 +20,8 @@ $(LIB): $(LIB_OBJS)
 
 $(BINS): $(LIB)
 
-bin/ttcp: LDFLAGS += -lboost_program_options
+bin/ttcp:
+	g++ $(CXXFLAGS) $(LDFLAGS) $(LDFLAGS) $(LIB_OBJS) $(LIB) bin/ttcp.cc -lboost_program_options -o bin/ttcp
 
 clean:
 	rm -f $(LIB_OBJS) $(LIB) $(BINS)


### PR DESCRIPTION
Ubuntu 18.04 LTS，内核 5.3.0  的环境下，库 boost_program_options 必须放在 bin/ttcp.cc 文件之后才能编译成功，我觉得可能和 g++ 的优化有关，放在之前如果未使用的话，可能直接忽略了。