### PR TITLE
Fix factory race condition

### DIFF
--- a/thread/test/Factory.cc
+++ b/thread/test/Factory.cc
@@ -213,8 +213,7 @@ class StockFactory : public boost::enable_shared_from_this<StockFactory>,
     {
       muduo::MutexLockGuard lock(mutex_);
       auto it = stocks_.find(stock->key());
-      assert(it != stocks_.end());
-      if (it->second.expired())
+      if (it != stocks_.end() && it->second.expired())
       {
         stocks_.erase(stock->key());
       }

--- a/thread/test/Factory_new_racecondition.cc
+++ b/thread/test/Factory_new_racecondition.cc
@@ -1,0 +1,124 @@
+// reproduce race condition of Factory.cc if compiled with -DREPRODUCE_BUG
+
+#include "../Mutex.h"
+
+#include <boost/noncopyable.hpp>
+
+#include <memory>
+#include <unordered_map>
+
+#include <assert.h>
+#include <stdio.h>
+#include <unistd.h>
+
+using std::string;
+
+void sleepMs(int ms)
+{
+  usleep(ms * 1000);
+}
+
+class Stock : boost::noncopyable
+{
+ public:
+  Stock(const string& name)
+    : name_(name)
+  {
+    printf("%s: Stock[%p] %s\n", muduo::CurrentThread::name(), this, name_.c_str());
+  }
+
+  ~Stock()
+  {
+    printf("%s: ~Stock[%p] %s\n", muduo::CurrentThread::name(), this, name_.c_str());
+  }
+
+  const string& key() const { return name_; }
+
+ private:
+  string name_;
+};
+
+
+class StockFactory : boost::noncopyable
+{
+ public:
+
+  std::shared_ptr<Stock> get(const string& key)
+  {
+    std::shared_ptr<Stock> pStock;
+    muduo::MutexLockGuard lock(mutex_);
+    std::weak_ptr<Stock>& wkStock = stocks_[key];
+    pStock = wkStock.lock();
+    if (!pStock)
+    {
+      pStock.reset(new Stock(key),
+                   [this] (Stock* stock) { deleteStock(stock); });
+      wkStock = pStock;
+    }
+    return pStock;
+  }
+
+ private:
+
+  void deleteStock(Stock* stock)
+  {
+    printf("%s: deleteStock[%p]\n", muduo::CurrentThread::name(), stock);
+    if (stock)
+    {
+      sleepMs(500);
+      muduo::MutexLockGuard lock(mutex_);
+#ifdef REPRODUCE_BUG
+      auto it = stocks_.find(stock->key());
+      assert(it != stocks_.end());
+      if (it->second.expired())
+      {
+        stocks_.erase(it);
+      }
+      else
+      {
+        printf("%s: %s is not expired\n", muduo::CurrentThread::name(), stock->key().c_str());
+      }
+#else
+      auto it = stocks_.find(stock->key());
+      if (it == stocks_.end())
+      {
+        printf("%s: %s had been deleted\n", muduo::CurrentThread::name(), stock->key().c_str());
+      }
+      else 
+      {
+        if (it->second.expired())
+        {
+          stocks_.erase(it);
+        }
+        else
+        {
+          printf("%s: %s is not expired\n", muduo::CurrentThread::name(), stock->key().c_str());
+        }
+      }
+#endif
+    }
+    delete stock;  // sorry, I lied
+  }
+
+  mutable muduo::MutexLock mutex_;
+  std::unordered_map<string, std::weak_ptr<Stock> > stocks_;
+};
+
+void threadB(StockFactory* factory)
+{
+  sleepMs(250);
+  auto stock = factory->get("MS");
+  printf("%s: stock %p\n", muduo::CurrentThread::name(), stock.get());
+}
+
+int main()
+{
+  StockFactory factory;
+  muduo::Thread thr([&factory] { threadB(&factory); }, "thrB");
+  thr.start();
+  {
+  auto stock = factory.get("MS");
+  printf("%s: stock %p\n", muduo::CurrentThread::name(), stock.get());
+  }
+  thr.join();
+}


### PR DESCRIPTION
首先说明，这个竟态问题不是我发现的，是一个知乎用户发现的，我只是重现和修复了这个竟态问题，详情见：https://zhuanlan.zhihu.com/p/30522095 下的讨论。

https://github.com/chenshuo/recipes/blob/5ba20b4c7f9eb566d0988964ceea19634e23bb36/thread/test/Factory.cc#L210

上面这个函数并没有完全解决竟态问题，比如：

1. 线程 1 调用 get("a") 创建 A，此时引用计数为 1
2. 线程 1 析构 A，此时引用计数为 0，开始调用 deletestock，但还未获取互斥锁
3. 线程 2 调用 get("a") 创建 B，此时引用计数为 1
4. 线程 2 析构 B，此时引用计数为 0，开始调用 deletestock，但还未获取互斥锁
5. 线程 1 获得互斥锁，调用剩余的 deletestock 函数，而后，释放互斥锁
6. 线程 2 获取互斥锁，调用 auto it = stocks_.find(stock->key()); 将返回 stocks_.end()，因为，上面的第 5 步，已经将该成员删了，之后的 assert(it != stocks_.end()); 将直接失败，而后退出

解决方法也很简单，如果查找失败，说明其他线程已经将该对象删除了，直接跳过删除即可

重新和修复详情见 PR
