### PR TITLE
fix-universal-reference-and-perfect-forwarding-bug

### DIFF
--- a/thread/SignalSlot.h
+++ b/thread/SignalSlot.h
@@ -120,22 +120,25 @@ class Signal<RET(ARGS...)> : boost::noncopyable
   {
   }
 
-  Slot connect(Callback&& func)
+  template<typename Func>
+  Slot connect(Func&& func)
   {
     boost::shared_ptr<SlotImpl> slotImpl(
-        new SlotImpl(impl_, std::forward<Callback>(func)));
+        new SlotImpl(impl_, std::forward<Func>(func)));
     add(slotImpl);
     return slotImpl;
   }
 
-  Slot connect(Callback&& func, const boost::shared_ptr<void>& tie)
+  template<typename Func>
+  Slot connect(Func&& func, const boost::shared_ptr<void>& tie)
   {
-    boost::shared_ptr<SlotImpl> slotImpl(new SlotImpl(impl_, func, tie));
+    boost::shared_ptr<SlotImpl> slotImpl(new SlotImpl(impl_, std::forward<Func>(func), tie));
     add(slotImpl);
     return slotImpl;
   }
 
-  void call(ARGS&&... args)
+  template<typename... Args>
+  void call(Args&&... args)
   {
     SignalImpl& impl(*impl_);
     boost::shared_ptr<typename SignalImpl::SlotList> slots;
@@ -155,12 +158,12 @@ class Signal<RET(ARGS...)> : boost::noncopyable
           guard = slotImpl->tie_.lock();
           if (guard)
           {
-            slotImpl->cb_(args...);
+            slotImpl->cb_(std::forward<Args>(args)...);
           }
         }
         else
         {
-          slotImpl->cb_(args...);
+          slotImpl->cb_(std::forward<Args>(args)...);
         }
       }
     }

--- a/thread/SignalSlotTrivial.h
+++ b/thread/SignalSlotTrivial.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <vector>
+#include <functional>
 
 template<typename Signature>
 class SignalTrivial;
@@ -13,19 +14,21 @@ class SignalTrivial<RET(ARGS...)>
  public:
   typedef std::function<void (ARGS...)> Functor;
 
-  void connect(Functor&& func)
+  template<typename Func>
+  void connect(Func&& func)
   {
-    functors_.push_back(std::forward<Functor>(func));
+    functors_.push_back(std::forward<Func>(func));
   }
 
-  void call(ARGS&&... args)
+  template<typename... Args>
+  void call(Args&&... args)
   {
     // gcc 4.6 supports
     //for (const Functor& f: functors_)
     typename std::vector<Functor>::iterator it = functors_.begin();
     for (; it != functors_.end(); ++it)
     {
-      (*it)(args...);
+      (*it)(std::forward<Args>(args)...);
     }
   }
 


### PR DESCRIPTION
在阅读代码时发现代码中的完美转发是有问题的：因为模板类的成员方法只是一个普通的函数，并不是一个模板函数，所以他们的参数不会触发类型推导，所以对于T&&类型只是一个普通的右值引用。原本的代码只能接收右值引用参数，但是这显然不是代码的本意，因为后面使用了std::forward进行完美转发，因此应该是一个universal reference才对。测试代码如下：
```cpp
#include <SignalSlotTrivial.h>
void compare1(string x, string y) {
    cout << "compare1" << endl;
}

int main() {
    SignalTrivial<void(string, string)> signal;
    function<void(string, string)> comapre3 = [](string x, string y) {
        cout << "compare2" << endl;
    };

    signal.connect(compare1);
    signal.connect([](string x, string y) {
        cout << "compare2" << endl;
    });
    //error:Rvalue reference to type 'function<...>' cannot bind to lvalue of type 'function<...>'
    signal.connect(comapre3);

    signal.call("Hello", "hello");
    string s1 = "Hello";
    string s2 = "hello";
    //error:Rvalue reference to type 'basic_string<...>' cannot bind to lvalue of type 'basic_string<...>'
    signal.call(s1, s2);

    return 0;
}
```
对于支持多线程实现同样也存在类似的问题。通过将`connect`和`call`函数都转换为模板成员函数就可以解决这个问题。